### PR TITLE
Demote errors as warnings in lr_get_XX() functions instead of ignoring them entirely

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # lightr (development version)
 
+## Major changes
+
+* Errors in low-level parsers are now passed as warnings in high-level 
+`lr_get_XXX()` functions instead of being completely silenced
+
 # lightr 1.6.0
 
 ## Major breaking changes

--- a/R/convert_tocsv.R
+++ b/R/convert_tocsv.R
@@ -56,9 +56,13 @@ lr_convert_tocsv <- function(where = NULL, ext = "txt", decimal = ".",
     p <- progressor(along = files)
     tmp <- future_lapply(files, function(x) {
       p()
-      tryCatch(spec2csv_single(x, decimal = decimal, sep = sep,
-                               overwrite = overwrite, metadata = metadata),
-               error = function(e) NULL)
+      tryCatch(
+        spec2csv_single(x, decimal = decimal, sep = sep,
+                        overwrite = overwrite, metadata = metadata),
+        error = function(e) {
+          warning(conditionMessage(e))
+          return(NULL)
+        })
     })
   })
 

--- a/R/get_metadata.R
+++ b/R/get_metadata.R
@@ -85,8 +85,12 @@ lr_get_metadata <- function(where = getwd(), ext = "ProcSpec", sep = NULL,
     p <- progressor(along = files)
     tmp <- future_lapply(files, function(x) {
       p()
-      tryCatch(gmd(x),
-               error = function(e) NULL)
+      tryCatch(
+        gmd(x),
+        error = function(e) {
+          warning(conditionMessage(e))
+          return(NULL)
+        })
     })
   })
 

--- a/R/get_spec.R
+++ b/R/get_spec.R
@@ -109,8 +109,12 @@ lr_get_spec <- function(where = getwd(), ext = "txt", lim = c(300, 700),
   p <- progressor(along = files)
   tmp <- future_lapply(files, function(x) {
     p()
-    tryCatch(gsp(x),
-             error = function(e) NULL)
+    tryCatch(
+      gsp(x),
+      error = function(e) {
+       warning(conditionMessage(e))
+       return(NULL)
+      })
     })
   })
 


### PR DESCRIPTION
Is this change a good idea? My reasoning is that it would help users identify where the problem comes from when some files cannot be read with `getspec()`/`lr_get_spec()`.

@thomased