### PR TITLE
Address tzdata breaking changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Minor changes
 
+* timezones for converted OceanOptics files are now handled differently internally (@Bisaloo, #64), 
+  to handle changes in upstream tzdata 2024b, which removed for example the CET and EST timezone codes.
+  This may result in some other deprecated timezone codes not being handled correctly.
+  Please report any bugs or discrepancies you may notice in the `datetime` field of metadata.
 * lightr now depends on R >= 4.0.0, following the tidyverse recommendation
 * the future package is now explicitly listed as a dependency, removing an `R CMD check` `NOTE` and thus removing the strain on CRAN reviewers. 
   The future package was already a indirect dependency via the future.apply package.

--- a/R/parse_avantes_binary.R
+++ b/R/parse_avantes_binary.R
@@ -318,7 +318,7 @@ lr_parse_rfl8 <- function(filename, specnum = 1L) {
                                dark_boxcar, white_boxcar, scope_boxcar)
 
     if (specnum == i) {
-      return(list("data" = data, "metadata" = metadata))
+      return(list(data = data, metadata = metadata))
     }
 
   }

--- a/R/parse_avantes_converted.R
+++ b/R/parse_avantes_converted.R
@@ -90,7 +90,7 @@ lr_parse_ttt <- function(filename) {
 
   data_final[match(colnames(data), cornames)] <- data
 
-  return(list("data" = data_final, "metadata" = metadata))
+  return(list(data = data_final, metadata = metadata))
 }
 
 #' @rdname lr_parse_ttt

--- a/R/parse_oceanoptics_converted.R
+++ b/R/parse_oceanoptics_converted.R
@@ -166,7 +166,7 @@ lr_parse_jaz <- function(filename) {
 
   data_final[match(colnames(data), cornames)] <- data
 
-  return(list("data" = data_final, "metadata" = unname(metadata)))
+  return(list(data = data_final, metadata = unname(metadata)))
 }
 
 #' @rdname lr_parse_jaz

--- a/R/parse_oceanoptics_converted.R
+++ b/R/parse_oceanoptics_converted.R
@@ -70,6 +70,7 @@ lr_parse_jaz <- function(filename) {
   if (tz == "") {
     tz <- "UTC"
   }
+  tz <- convert_backward_tzdata(tz)
 
   # OceanOptics files use locale-dependent date formats but it looks like they
   # are always using English for this, even when the locale is not set to

--- a/R/parse_oceanoptics_converted.R
+++ b/R/parse_oceanoptics_converted.R
@@ -61,6 +61,8 @@ lr_parse_jaz <- function(filename) {
   tz <- ""
 
   if (grepl(oo_savetime_regex, savetime)) {
+    # The value we extract here might not follow the official naming and could
+    # not be recognized by tzdata.
     tz <- trimws(gsub(oo_savetime_regex, "\\2", savetime))
     savetime <- gsub(oo_savetime_regex, "\\1 \\3", savetime)
   }

--- a/R/parse_spc.R
+++ b/R/parse_spc.R
@@ -53,6 +53,6 @@ lr_parse_spc <- function(filename) {
 
   metadata <- rep(NA_character_, 13)
 
-  return(list("data" = as.data.frame(data), "metadata" = metadata))
+  return(list(data = as.data.frame(data), metadata = metadata))
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,8 +12,8 @@ convert_backward_tzdata <- function(tz) {
   # new test files.
   switch(
     tz,
-    "EST" = "America/Panama",
-    "CET" = "Europe/Brussels",
+    EST = "America/Panama",
+    CET = "Europe/Brussels",
     tz
   )
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,3 +3,18 @@ int32_to_uint32 <- function(int32) {
   ifelse(int32 >= 0, int32, 2^31 - 1 + int32)
 
 }
+
+convert_backward_tzdata <- function(tz) {
+
+  # Convert timezones removed in tzdata 2024b.
+  # This is a subset of what tzdata-backward is providing, based on cases we
+  # could observe in test files. It can be expanded based on user feedback and
+  # new test files.
+  switch(
+    tz,
+    "EST" = "America/Panama",
+    "CET" = "Europe/Brussels",
+    tz
+  )
+
+}


### PR DESCRIPTION
As reported by CRAN:

> ```
> Dear maintainer,
> 
> Please see the problems shown on https://cran.r-project.org/web/checks/check_results_lightr.html.
> 
> The errors on the Debian check systems are from a recent system upgrade
> to tzdata 2024b which did
> 
>    Names present only for compatibility with UNIX System V
>    (last released in the 1990s) have been moved to 'backward'.
> 
> which includes CET, CST6CDT, EET, EST*, HST, MET, MST*, PST8PDT, and
> WET.
> 
> Debian ships the names in 'backward' in a separate package tzdata-legacy
> which is not installed "by default".
> 
> The comments in the tzdata 'backward' file say
> 
> # Although this file is optional and tzdb will work if you omit it by
> # building with 'make BACKWARD=', in practice downstream users
> # typically use this file for backward compatibility.
> 
> so clearly one cannot unconditionally assume that the backward
> compatibility names will work.
> ```

To be fixed before 2024-12-09